### PR TITLE
[ CI ] Add CI link automated commits

### DIFF
--- a/.github/workflows/ci-db.yml
+++ b/.github/workflows/ci-db.yml
@@ -27,7 +27,7 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add collections/*.toml
-          git commit -m "[ new ] todays nightly"
+          git commit -m "[ new ] todays nightly" -m "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
Can be useful for tracing/debugging builds.

Passing `-m` twice should [format the commit correctly](https://stackoverflow.com/questions/5064563/add-line-break-to-git-commit-m-from-the-command-line), but maybe would be better to use a heredoc.

Also just tested the output of those environment variables [here](https://github.com/alexhumphreys/idris2-node-postgres/runs/6720710535?check_suite_focus=true#step:4:1) so it should link to the correct run.