### PR TITLE
add idris2-promise, which was extracted from tyttp

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -226,6 +226,12 @@ url    = "https://github.com/cuddlefishie/toml-idr"
 commit = "main"
 ipkg   = "toml.ipkg"
 
+[db.promise]
+type = "github"
+url  = "https://github.com/kbertalan/idris2-promise"
+commit = "main"
+ipkg = "promise.ipkg"
+
 [db.tyttp]
 type = "github"
 url  = "https://github.com/kbertalan/tyttp"


### PR DESCRIPTION
This is the promise implementation which was used in `tyttp`.
It is now extracted as it seems to be stable enough to be in a separate library.