### PR TITLE
[ CI ] simplify and add CI on PRs

### DIFF
--- a/.github/workflows/ci-db.yml
+++ b/.github/workflows/ci-db.yml
@@ -16,43 +16,36 @@ defaults:
 jobs:
 
   build:
-    name: Run installation script
+    name: Create package collection
     runs-on: ubuntu-latest
+    env:
+      PACK_DIR: /root/.pack
+    strategy:
+      fail-fast: false
+    container: ghcr.io/stefan-hoeck/idris2-pack:latest
     steps:
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install --yes gcc make chezscheme libgmp3-dev nodejs
-      - name: Checkout pack
-        uses: actions/checkout@v3
-        with:
-          repository: stefan-hoeck/idris2-pack
-      - name: Run MicroPack
-        run: |
-          make micropack SCHEME="chezscheme"
-          echo "$HOME/.pack/bin" >> "$GITHUB_PATH"
-      - name: Build pack-admin
-        run: $HOME/.pack/bin/pack --no-prompt build pack-admin.ipkg
-      - name: Extract Collection from HEAD
-        run: build/exec/pack-admin --no-prompt extract-from-head "$HOME/.pack/db/testdb.toml"
-      - name: Check Collection
-        run: |
-          mkdir $HOME/output
-          build/exec/pack-admin --no-prompt check-collection testdb $HOME/output/STATUS.md
       - name: Checkout
         uses: actions/checkout@v3
-        if: always()
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Install pack-admin
+        run: pack --no-prompt install-app pack-admin
+      - name: Extract Collection from HEAD
+        run: build/exec/pack-admin --no-prompt extract-from-head "$PACK_DIR/db/testdb.toml"
+      - name: Check Collection
+        run: |
+          mkdir $PACK_DIR/output
+          pack-admin --no-prompt check-collection testdb STATUS.md
       - name: Add STATUS.md
         if: always()
         run: |
-          cp "$HOME/output/STATUS.md" STATUS.md
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add STATUS.md
       - name: Git add collection
         run: |
-          cp "$HOME/.pack/db/testdb.toml" "collections/nightly-$(date +%y%m%d).toml"
+          cp "$PACK_DIR/db/testdb.toml" "collections/nightly-$(date +%y%m%d).toml"
           git add collections/*.toml
       - name: Git commit
         if: always()

--- a/.github/workflows/ci-db.yml
+++ b/.github/workflows/ci-db.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install libgsl-dev
-          apt-get install libpq-dev
+          apt-get install --yes libgsl-dev
+          apt-get install --yes libpq-dev
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/.github/workflows/ci-db.yml
+++ b/.github/workflows/ci-db.yml
@@ -31,9 +31,9 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install libgsl-dev
-          sudo apt-get install libpq-dev
+          apt-get update
+          apt-get install libgsl-dev
+          apt-get install libpq-dev
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/.github/workflows/ci-db.yml
+++ b/.github/workflows/ci-db.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Use latest pack commit
+        run: pack update
       - name: Install pack-admin
         run: pack --no-prompt install-app pack-admin
       - name: Extract Collection from HEAD

--- a/.github/workflows/ci-db.yml
+++ b/.github/workflows/ci-db.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgsl-dev
+          sudo apt-get install libpq-dev
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,36 @@
+---
+name: Check Collection
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  build:
+    name: Check package collection
+    runs-on: ubuntu-latest
+    env:
+      PACK_DIR: /root/.pack
+    strategy:
+      fail-fast: false
+    container: ghcr.io/stefan-hoeck/idris2-pack:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install pack-admin
+        run: pack --no-prompt install-app pack-admin
+      - name: Extract Collection from HEAD
+        run: pack-admin --no-prompt extract-from-head "$PACK_DIR/db/testdb.toml"
+      - name: Check Collection
+        run: pack-admin --no-prompt check-collection testdb STATUS.md

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install libgsl-dev
-          apt-get install libpq-dev
+          apt-get install --yes libgsl-dev
+          apt-get install --yes libpq-dev
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -28,6 +28,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgsl-dev
+          sudo apt-get install libpq-dev
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Use latest pack commit
+        run: pack update
       - name: Install pack-admin
         run: pack --no-prompt install-app pack-admin
       - name: Extract Collection from HEAD

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install libgsl-dev
-          sudo apt-get install libpq-dev
+          apt-get update
+          apt-get install libgsl-dev
+          apt-get install libpq-dev
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/pack.toml
+++ b/pack.toml
@@ -1,0 +1,5 @@
+[custom.all.pack-admin]
+type   = "github"
+url    = "https://github.com/stefan-hoeck/idris2-pack"
+commit = "latest:main"
+ipkg   = "pack-admin.ipkg"

--- a/pack.toml
+++ b/pack.toml
@@ -1,5 +1,13 @@
+pack.commit = "latest:main"
+
 [custom.all.pack-admin]
 type   = "github"
 url    = "https://github.com/stefan-hoeck/idris2-pack"
 commit = "latest:main"
 ipkg   = "pack-admin.ipkg"
+
+[custom.all.pack]
+type   = "github"
+url    = "https://github.com/stefan-hoeck/idris2-pack"
+commit = "latest:main"
+ipkg   = "pack.ipkg"


### PR DESCRIPTION
With this PR, we start using the latest docker image from pack, but we make sure to use the latest `pack-admin`. In addition, we now check the package collection on PRs.