### PR TITLE
Add ncurses library to pack registry.

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -33,6 +33,8 @@ jobs:
           apt-get update
           apt-get install --yes libgsl-dev
           apt-get install --yes libpq-dev
+          # ncurses-idris:
+          apt-get install --yes libncurses-dev libc6-dev
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -30,6 +30,8 @@ jobs:
           apt-get update
           apt-get install --yes libgsl-dev
           apt-get install --yes libpq-dev
+          # ncurses-idris:
+          apt-get install --yes libncurses-dev libc6-dev
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -175,6 +175,12 @@ url    = "https://github.com/MarcelineVQ/idris2-newtype-deriving"
 commit = "master"
 ipkg   = "newtype-deriving.ipkg"
 
+[db.ncurses-idris]
+type   = "github"
+url    = "https://github.com/mattpolzin/ncurses-idris"
+commit = "main"
+ipkg   = "ncurses-idris.ipkg"
+
 [db.pack]
 type   = "github"
 url    = "https://github.com/stefan-hoeck/idris2-pack"


### PR DESCRIPTION
I've finally modified the NCurses build to run C helper compilation through `ipkg` hooks so it should now be a reasonable addition to the Pack package set.