### PR TITLE
[ temp ] temporarily disabling ncurses-idris

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -284,11 +284,11 @@ test   = "test/test.ipkg"
 # commit = "master"
 # ipkg   = "newtype-deriving.ipkg"
 
-[db.ncurses-idris]
-type   = "github"
-url    = "https://github.com/mattpolzin/ncurses-idris"
-commit = "main"
-ipkg   = "ncurses-idris.ipkg"
+# [db.ncurses-idris]
+# type   = "github"
+# url    = "https://github.com/mattpolzin/ncurses-idris"
+# commit = "main"
+# ipkg   = "ncurses-idris.ipkg"
 
 [db.pack]
 type   = "github"


### PR DESCRIPTION
I'm temporarily disabling ncurses-idris until issue mattpolzin/ncurses-idris#34 has been fixed so that we can still get a new nightly.