### PR TITLE
Revert "[ temp ] temporarily disabling ncurses-idris"

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -290,11 +290,11 @@ test   = "test/test.ipkg"
 # commit = "master"
 # ipkg   = "newtype-deriving.ipkg"
 
-# [db.ncurses-idris]
-# type   = "github"
-# url    = "https://github.com/mattpolzin/ncurses-idris"
-# commit = "main"
-# ipkg   = "ncurses-idris.ipkg"
+[db.ncurses-idris]
+type   = "github"
+url    = "https://github.com/mattpolzin/ncurses-idris"
+commit = "main"
+ipkg   = "ncurses-idris.ipkg"
 
 [db.pack]
 type   = "github"


### PR DESCRIPTION
Reverts stefan-hoeck/idris2-pack-db#110

The build issue due to a bug in totality should be resolved now on the main branch of `ncurses-idris`.