### PR TITLE
Add utf8 package

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -667,6 +667,7 @@ type   = "github"
 url    = "https://git.sr.ht/~janus/utf8"
 commit = "master"
 ipkg   = "utf8.ipkg"
+test   = "test/test.ipkg"
 
 [db.webidl]
 type   = "github"

--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -662,6 +662,12 @@ url    = "https://github.com/Z-snails/uniplate-idr"
 commit = "main"
 ipkg   = "uniplate.ipkg"
 
+[db.utf8]
+type   = "github"
+url    = "https://git.sr.ht/~janus/utf8"
+commit = "master"
+ipkg   = "utf8.ipkg"
+
 [db.webidl]
 type   = "github"
 url    = "https://github.com/stefan-hoeck/idris2-webidl"


### PR DESCRIPTION
This package only supports Chez/Racket for now, but it would be nice to have it support other backends. I pointed this out in it's `brief` field.
