### PR TITLE
Add cont, buf-conn, http2, pg, pg-types, racket-tcp, web-server-racket, web-server-racket-hello-world

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -700,3 +700,51 @@ url    = "https://github.com/joelberkeley/c-ffi"
 commit = "master"
 ipkg   = "c-ffi.ipkg"
 test   = "test.ipkg"
+
+[db.cont]
+type = "github"
+url  = "https://git.sr.ht/~janus/cont"
+commit = "master"
+ipkg = "cont.ipkg"
+
+[db.buf-conn]
+type = "github"
+url = "https://git.sr.ht/~janus/buf-conn"
+commit = "master"
+ipkg = "buf-conn.ipkg"
+
+[db.http2]
+type = "github"
+url = "https://git.sr.ht/~janus/http2"
+commit = "master"
+ipkg = "http2.ipkg"
+
+[db.pg]
+type = "github"
+url = "https://git.sr.ht/~janus/pg"
+commit = "master"
+ipkg = "pg.ipkg"
+
+[db.pg-types]
+type = "github"
+url = "https://git.sr.ht/~janus/pg-types"
+commit = "master"
+ipkg = "pg-types.ipkg"
+
+[db.racket-tcp]
+type = "github"
+url = "https://git.sr.ht/~janus/racket-tcp"
+commit = "master"
+ipkg = "racket-tcp.ipkg"
+
+[db.web-server-racket]
+type = "github"
+url = "https://git.sr.ht/~janus/web-server-racket"
+commit = "master"
+ipkg = "web-server-racket.ipkg"
+
+[db.web-server-racket-hello-world]
+type = "github"
+url = "https://git.sr.ht/~janus/web-server-racket-hello-world"
+commit = "master"
+ipkg = "web-server-racket-hello-world.ipkg"


### PR DESCRIPTION
Added packages, starting with the leaves of the dependency tree:
<dl>
<dt><tt>cont</tt>
<dd>Double-barreled continuations. Used in the <tt>pg</tt>, <tt>http2</tt>, <tt>web-server-racket</tt> packages.
<dt><tt>buf-conn</tt>
<dd>Buffered connection (as in TCP). Based on continuations. Let's you only read the amount of bytes you want.
<dt><tt>pg-types</tt>
<dd>Data types for PostgreSQL clients. Used in the <tt>pg</tt> and <tt>http2</tt> packages.
<dt><tt>http2</tt>
<dd>Continuation based HTTP2 server. No IO. Used in <tt>web-server-racket</tt>.
<dt><tt>pg</tt>
<dd>Continuation based PostgreSQL client. No IO use. Used in <tt>web-server-racket</tt>.
<dt><tt>racket-tcp</tt>
<dd>Thin bindings to the <tt>racket/tcp</tt> library. Supports concurrency using the Racket custodian.
<dt><tt>web-server-racket</tt>
<dd>HTTP2 server with PostgreSQL access. See usage example in <tt>web-server-racket-hello-world</tt>. Only supports Racket due to reliance on the <tt>racket-tcp</tt> library.
<dt><tt>web-server-racket-hello-world</tt>
<dd>Example demo web server that computes 1+1 on a PostgreSQL server and returns the result over HTTP2. Racket only.
</dl>