### PR TITLE
Rename `lsp` to `idris2-lsp`

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -282,11 +282,11 @@ url    = "https://github.com/kiana-S/idris2-lens"
 commit = "main"
 ipkg   = "lens.ipkg"
 
-[db.lsp]
+[db.idris2-lsp]
 type        = "github"
 url         = "https://github.com/idris-community/idris2-lsp"
 commit      = "main"
-ipkg        = "lsp.ipkg"
+ipkg        = "idris2-lsp.ipkg"
 packagePath = true
 
 [db.lsp-lib]


### PR DESCRIPTION
We are about to split `idris2-lsp` into `LSP-lib` (reusable model of LSP written in idris2) and `idris2-lsp` that will depend on `LSP-lib`. `LSP-lib` encourages authors to write LSP servers for other programming languages in Idris2. So it makes sense to change the name under which `idris2-lsp` is distributed via pack from generic `lsp` to more specific `idris2-lsp`.

EDIT: I guess CI will only pass when we merge the split. 