### PR TITLE
[ hedgehog ] Enable existing tests in the db descriptor

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -198,6 +198,7 @@ type   = "github"
 url    = "https://github.com/stefan-hoeck/idris2-hedgehog"
 commit = "main"
 ipkg   = "hedgehog.ipkg"
+tsst   = "tests/tests.ipkg"
 
 [db.idrall]
 type   = "github"


### PR DESCRIPTION
Several PR's ago tests were added to `hedgehog`, but their status is not shown in the `STATUS.md`