### PR TITLE
Add `string-search`

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -534,6 +534,13 @@ commit = "main"
 ipkg   = "string-builder.ipkg"
 test   = "test/test.ipkg"
 
+[db.string-search]
+type   = "github"
+url    = "https://git.sr.ht/~janus/string-search"
+commit = "master"
+ipkg   = "string-search.ipkg"
+test   = "test/test.ipkg"
+
 [db.summary-stat]
 type   = "github"
 url    = "https://github.com/buzden/idris2-summary-stat"


### PR DESCRIPTION
This is a tiny package that provides string splitting functionality based on `memmem`. I needed this for a multi-part/MIME parser.
