### PR TITLE
[ fix ] manually adjust Git commit for idris2-lsp in latest nightly

### DIFF
--- a/collections/nightly-240309.toml
+++ b/collections/nightly-240309.toml
@@ -350,7 +350,7 @@ test        = "tests/libtests.ipkg"
 [db.idris2-lsp]
 type        = "github"
 url         = "https://github.com/idris-community/idris2-lsp"
-commit      = "a77ef2d563418925aa274fa29f06880dde43f4ec"
+commit      = "07e751bb6372b496844ba0fc22c1692b22e98919"
 ipkg        = "idris2-lsp.ipkg"
 packagePath = true
 


### PR DESCRIPTION
I typically don't manually interfer with the generated nightlies, but `nightly-240309` is not usable, because idris2-lsp does not work due to upstream changes in the Idris compiler. So, we can either delete the nightly or adjust the idris2-lsp commit, since idris2-lsp has been fixed by now. I decided for the latter.