### PR TITLE
[ new ] add tyttp adapter node

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -664,6 +664,12 @@ url  = "https://github.com/kbertalan/tyttp"
 commit = "main"
 ipkg = "tyttp.ipkg"
 
+[db.tyttp-adapter-node]
+type = "github"
+url  = "https://github.com/kbertalan/tyttp"
+commit = "main"
+ipkg = "adapter-node/tyttp-adapter-node.ipkg"
+
 [db.tyttp-json]
 type = "github"
 url  = "https://github.com/kbertalan/tyttp-json"


### PR DESCRIPTION
It is required for external projects which would like to use tyttp on node. Also required for tyttp-json tests.