### PR TITLE
[change] tyttp-json location and enable tests for tyttp packages

### DIFF
--- a/.github/workflows/ci-db.yml
+++ b/.github/workflows/ci-db.yml
@@ -44,6 +44,8 @@ jobs:
           apt-get install --yes golang-go
           # libuv
           apt-get install --yes libuv1-dev
+          # node codegen:
+          apt-get install --yes nodejs
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,6 +46,8 @@ jobs:
           apt-get install --yes golang-go
           # libuv
           apt-get install --yes libuv1-dev
+          # node codegen:
+          apt-get install --yes nodejs
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -41,6 +41,8 @@ jobs:
           apt-get install --yes golang-go
           # libuv
           apt-get install --yes libuv1-dev
+          # node codegen:
+          apt-get install --yes nodejs
       - name: Use latest pack commit
         run: pack update
       - name: Install pack-admin

--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -663,18 +663,21 @@ type = "github"
 url  = "https://github.com/kbertalan/tyttp"
 commit = "main"
 ipkg = "tyttp.ipkg"
+test = "tests/tests.ipkg"
 
 [db.tyttp-adapter-node]
 type = "github"
 url  = "https://github.com/kbertalan/tyttp"
 commit = "main"
 ipkg = "adapter-node/tyttp-adapter-node.ipkg"
+test = "tests/tests.ipkg"
 
 [db.tyttp-json]
 type = "github"
-url  = "https://github.com/kbertalan/tyttp-json"
+url  = "https://github.com/kbertalan/tyttp"
 commit = "main"
-ipkg = "tyttp-json.ipkg"
+ipkg = "json/tyttp-json.ipkg"
+test = "tests/tests.ipkg"
 
 [db.xml]
 type   = "github"

--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -670,14 +670,14 @@ type = "github"
 url  = "https://github.com/kbertalan/tyttp"
 commit = "main"
 ipkg = "adapter-node/tyttp-adapter-node.ipkg"
-test = "tests/tests.ipkg"
+test = "adapter-node/tests/tests.ipkg"
 
 [db.tyttp-json]
 type = "github"
 url  = "https://github.com/kbertalan/tyttp"
 commit = "main"
 ipkg = "json/tyttp-json.ipkg"
-test = "tests/tests.ipkg"
+test = "json/tests/tests.ipkg"
 
 [db.xml]
 type   = "github"


### PR DESCRIPTION
- tyttp-json has been moved from its own github repository to tyttp repository
- tests were implemented for a while, but they were not enabled in pack-db before