### PR TITLE
[ admin ] temporarily disable tls and http

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -800,17 +800,17 @@ url    = "https://github.com/running-grass/idris2-url"
 commit = "main"
 ipkg   = "url.ipkg"
 
-[db.tls]
-type   = "github"
-url    = "https://github.com/octeep/idris2-tls"
-commit = "master"
-ipkg   = "tls.ipkg"
-
-[db.http]
-type   = "github"
-url    = "https://github.com/octeep/idris2-http"
-commit = "master"
-ipkg   = "http.ipkg"
+# [db.tls]
+# type   = "github"
+# url    = "https://github.com/octeep/idris2-tls"
+# commit = "master"
+# ipkg   = "tls.ipkg"
+# 
+# [db.http]
+# type   = "github"
+# url    = "https://github.com/octeep/idris2-http"
+# commit = "master"
+# ipkg   = "http.ipkg"
 
 [db.prob-fx]
 type   = "github"


### PR DESCRIPTION
Packages tls and http are currently broken. I informed the author but got no response so far. I'm therefore going to temporarily disable those two packages. Once they are fixed, we can enable them again.