### PR TITLE
Add Katla-pandoc

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -397,6 +397,12 @@ url    = "https://github.com/idris-community/katla"
 commit = "main"
 ipkg   = "katla.ipkg"
 
+[db.katla-pandoc]
+type   = "github"
+url    = "https://github.com/idris-community/katla"
+commit = "main"
+ipkg   = "katla-pandoc.ipkg"
+
 [db.lana]
 type   = "github"
 url    = "https://git.sr.ht/~janus/lana"


### PR DESCRIPTION
If I understand correctly, this should allow katla-pandoc to be installed with `pack install-app katla-pandoc`, is that right?