### PR TITLE
[ remove ] Comment out suddenly disappeared packages

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -1007,24 +1007,6 @@ ipkg   = "http.ipkg"
 # commit = "main"
 # ipkg   = "prob-fx.ipkg"
 
-[db.cheerio]
-type   = "github"
-url    = "https://github.com/running-grass/idris2-playground"
-commit = "main"
-ipkg   = "cheerio/cheerio.ipkg"
-
-[db.matrix]
-type   = "github"
-url    = "https://github.com/running-grass/idris2-playground"
-commit = "main"
-ipkg   = "matrix/matrix.ipkg"
-
-[db.game-2048]
-type   = "github"
-url    = "https://github.com/running-grass/idris2-playground"
-commit = "main"
-ipkg   = "game-2048/game-2048.ipkg"
-
 [db.uniplate]
 type   = "github"
 url    = "https://github.com/Z-snails/uniplate-idr"


### PR DESCRIPTION
This breaks not only the new pack collection build, but any type of work with `pack`, since now `pack` is designed to synchronise every package repository, even when it's actually unused.

Maybe @running-grass could come in an say whether this is a permanent deletion or not