### PR TITLE
[ fix ] URL of hashable-derive

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -426,7 +426,7 @@ ipkg   = "hashable.ipkg"
 
 [db.hashable-derive]
 type = "github"
-url = "https://github.com//uartman/hashable-derive"
+url = "https://github.com/uartman/hashable-derive"
 commit = "main"
 ipkg = "hashable-derive.ipkg"
 


### PR DESCRIPTION
The additional `/` is causing a failure in a fresh install (during `pack info`)