### PR TITLE
[ new ] add log4types, log4types-core and log4types-json

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -589,6 +589,27 @@ url    = "https://github.com/stefan-hoeck/idris2-literal"
 commit = "main"
 ipkg   = "literal.ipkg"
 
+[db.log4types]
+type   = "github"
+url    = "https://github.com/bio-aeon/log4types"
+commit = "main"
+ipkg   = "log4types/log4types.ipkg"
+test   = "log4types/test/test.ipkg"
+
+[db.log4types-core]
+type   = "github"
+url    = "https://github.com/bio-aeon/log4types"
+commit = "main"
+ipkg   = "log4types-core/log4types-core.ipkg"
+test   = "log4types-core/test/test.ipkg"
+
+[db.log4types-json]
+type   = "github"
+url    = "https://github.com/bio-aeon/log4types"
+commit = "main"
+ipkg   = "log4types-json/log4types-json.ipkg"
+test   = "log4types-json/test/test.ipkg"
+
 [db.idris2-lsp]
 type        = "github"
 url         = "https://github.com/idris-community/idris2-lsp"


### PR DESCRIPTION
This PR adds `log4types` - a general-purpose application logging library for Idris 2.

There are three packages:
- `log4types-core` - core algebra: LogAction, combinators, severity, structured values.
- `log4types` - application logging: messages, IO actions, formatting, context.
- `log4types-json` - JSON backend for structured log output.