### PR TITLE
fix stellar http module 

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -553,6 +553,12 @@ commit = "main"
 ipkg   = "json.ipkg"
 test   = "test/test.ipkg"
 
+[db.json-schema]
+type   = "github"
+url    = "https://github.com/madman-bob/idris2-json-schema"
+commit = "main"
+ipkg   = "json-schema.ipkg"
+
 [db.json-simple]
 type   = "github"
 url    = "https://github.com/stefan-hoeck/idris2-json"

--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -1016,11 +1016,17 @@ url    = "https://gitlab.com/avidela/stellar"
 commit = "main"
 ipkg   = "api/stellar-api.ipkg"
 
-[db.stellar-http]
+[db.stellar-http-node]
 type   = "git"
 url    = "https://gitlab.com/avidela/stellar"
 commit = "main"
-ipkg   = "http/stellar-http.ipkg"
+ipkg   = "http/stellar-http-node.ipkg"
+
+[db.stellar-http-scheme]
+type   = "git"
+url    = "https://gitlab.com/avidela/stellar"
+commit = "main"
+ipkg   = "http/stellar-http-scheme.ipkg"
 
 [db.stellar-sql]
 type   = "git"


### PR DESCRIPTION
I split the stellar-http module in two `stellar-http-node` and `stellar-http-scheme` this change reflects that since `stellar-http` is gone