### PR TITLE
[ new ] add lsm-rrbvector library

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -1419,3 +1419,10 @@ url    = "https://github.com/Matthew-Mosior/idris2-resource-pool"
 commit = "main"
 ipkg   = "resource-pool.ipkg"
 test   = "test/test.ipkg"
+
+[db.lsm-rrbvector]
+type   = "github"
+url    = "https://github.com/Matthew-Mosior/idris2-lsm-rrbvector"
+commit = "main"
+ipkg   = "lsm-rrbvector.ipkg"
+test   = "test/test.ipkg"


### PR DESCRIPTION
This PR adds a new library, [lsm-rrbvector](https://github.com/Matthew-Mosior/idris2-lsm-rrbvector).