### PR TITLE
[ new ] add yaml

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -1426,3 +1426,10 @@ url    = "https://github.com/Matthew-Mosior/idris2-lsm-rrbvector"
 commit = "main"
 ipkg   = "lsm-rrbvector.ipkg"
 test   = "test/test.ipkg"
+
+[db.yaml]
+type   = "github"
+url    = "https://github.com/mitchmindtree/idris2-yaml"
+commit = "main"
+ipkg   = "yaml.ipkg"
+test   = "test/test.ipkg"


### PR DESCRIPTION
This PR adds `yaml`, a pure, total YAML 1.2.2 parser and composer built on the `parser`/`ilex-core` libraries. It passes all 402 cases of the official [YAML test suite](https://github.com/yaml/yaml-test-suite) (vendored, wired up via the test field) and needs no extra system dependencies, so the workflows are untouched.