### PR TITLE
[ new ] add evince-async, evince-async-js and evince-async-posix

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -345,6 +345,26 @@ commit = "main"
 ipkg   = "evince/evince.ipkg"
 test   = "evince/test/test.ipkg"
 
+[db.evince-async]
+type   = "github"
+url    = "https://github.com/bio-aeon/evince"
+commit = "main"
+ipkg   = "evince-async/evince-async.ipkg"
+test   = "evince-async/test/test.ipkg"
+
+[db.evince-async-js]
+type   = "github"
+url    = "https://github.com/bio-aeon/evince"
+commit = "main"
+ipkg   = "evince-async-js/evince-async-js.ipkg"
+
+[db.evince-async-posix]
+type   = "github"
+url    = "https://github.com/bio-aeon/evince"
+commit = "main"
+ipkg   = "evince-async-posix/evince-async-posix.ipkg"
+test   = "evince-async-posix/test/test.ipkg"
+
 [db.evince-hedgehog]
 type   = "github"
 url    = "https://github.com/bio-aeon/evince"


### PR DESCRIPTION
The three optional async execution drivers for [evince](https://github.com/bio-aeon/evince). They runs top-level test groups concurrently by binding a different `idris2-async` loop:

- `evince-async` - single-threaded concurrency on the `SyncST` loop (Chez/Racket).
- `evince-async-js` - single-threaded concurrency on the JS event loop (Node).
- `evince-async-posix` - true multi-core parallelism on the posix `ThreadPool` (Chez).