### PR TITLE
[ new ] add bcrypt library

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -1491,3 +1491,9 @@ type   = "github"
 url    = "https://github.com/Matthew-Mosior/idris2-oracle"
 commit = "main"
 ipkg   = "oracle.ipkg"
+
+[db.bcrypt]
+type   = "github"
+url    = "https://github.com/Matthew-Mosior/idris2-bcrypt"
+commit = "main"
+ipkg   = "bcrypt.ipkg"


### PR DESCRIPTION
This PR adds a new library, [bcrypt](https://github.com/Matthew-Mosior/idris2-bcrypt).