### PR TITLE
[ new ] add cats-and-arrows to collection

### DIFF
--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -631,7 +631,7 @@ ipkg   = "lana.ipkg"
 
 [db.lens]
 type   = "github"
-url    = "https://github.com/kiana-S/idris2-lens"
+url    = "https://github.com/tokinanpa/idris2-lens"
 commit = "main"
 ipkg   = "lens.ipkg"
 
@@ -742,7 +742,7 @@ ipkg   = "nested.ipkg"
 
 [db.numidr]
 type   = "github"
-url    = "https://github.com/kiana-S/numidr"
+url    = "https://github.com/tokinanpa/numidr"
 commit = "main"
 ipkg   = "numidr.ipkg"
 
@@ -915,7 +915,7 @@ ipkg   = "profiler.ipkg"
 
 [db.profunctors]
 type   = "github"
-url    = "https://github.com/kiana-S/idris2-profunctors"
+url    = "https://github.com/tokinanpa/idris2-profunctors"
 commit = "main"
 ipkg   = "profunctors.ipkg"
 
@@ -940,7 +940,7 @@ test   = "tests/tests.ipkg"
 
 [db.ratio]
 type   = "github"
-url    = "https://github.com/kiana-S/idris2-ratio"
+url    = "https://github.com/tokinanpa/idris2-ratio"
 commit = "main"
 ipkg   = "ratio.ipkg"
 

--- a/collections/HEAD.toml
+++ b/collections/HEAD.toml
@@ -143,6 +143,12 @@ url    = "https://github.com/stefan-hoeck/idris2-bytestring"
 commit = "main"
 ipkg   = "bytestring.ipkg"
 
+[db.cats-and-arrows]
+type   = "github"
+url    = "https://github.com/tokinanpa/cats-and-arrows"
+commit = "main"
+ipkg   = "cats-and-arrows.ipkg"
+
 [db.chem]
 type   = "github"
 url    = "https://github.com/stefan-hoeck/idris2-chem"


### PR DESCRIPTION
About a week ago, I submitted a feature request to Idris2 to [add arrow notation as a language extension](https://github.com/idris-lang/Idris2/issues/3837). It was mostly rejected, which I kind of expected, but [one of the replies](https://github.com/idris-lang/Idris2/issues/3837#issuecomment-5327798270) to that proposal made an interesting point that arrows themselves have the potential to be reworked from first principles in the setting of dependent types.

After thinking on the subject for a few days and putting my thoughts to Idris code, this is the result: [`cats-and-arrows`](https://github.com/tokinanpa/cats-and-arrows/tree/main), a category theory library that (with any luck) will eventually be the foundation for an all-new *string diagram notation*.

It's nowhere near a usable state yet, but it does build, so I'm adding it to the package list in case anyone wants to mess around with it. I'll probably include more detail on its design, along with occasional progress updates, in the `#projects` channel of the community Zulip instance.

(This PR also updates the URLs of some of my other packages to reflect my updated username.)